### PR TITLE
Remove Extra Curly Bracket in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
       # Gets the release tag
       - name: Get the release tag
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}}
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       # Send release notes to ms teams
       - uses: Stompf/ms-teams-deploy-release-card@main #  or "./" if in a local set-up


### PR DESCRIPTION
Extra curly bracket in readme causes action to fail if you copy the example directly. Get "Error: Not Found" Message because the tag name has a trailing curly bracket on it. 